### PR TITLE
Clean install project dependencies

### DIFF
--- a/examples/browser/tsconfig.json
+++ b/examples/browser/tsconfig.json
@@ -60,6 +60,9 @@
       "path": "../../packages/ai-openai"
     },
     {
+      "path": "../../packages/ai-opencog"
+    },
+    {
       "path": "../../packages/ai-scanoss"
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "sample-plugins/*/*"
       ],
       "devDependencies": {
+        "@nx/nx-linux-x64-gnu": "^21.3.11",
         "@types/chai": "4.3.0",
         "@types/chai-spies": "1.0.3",
         "@types/chai-string": "^1.4.0",
@@ -265,6 +266,7 @@
     "dev-packages/ffmpeg": {
       "name": "@theia/ffmpeg",
       "version": "1.64.0",
+      "hasInstallScript": true,
       "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
       "dependencies": {
         "@electron/get": "^2.0.0",
@@ -471,6 +473,7 @@
         "@theia/ai-mcp-ui": "1.64.0",
         "@theia/ai-ollama": "1.64.0",
         "@theia/ai-openai": "1.64.0",
+        "@theia/ai-opencog": "1.64.0",
         "@theia/ai-scanoss": "1.64.0",
         "@theia/ai-terminal": "1.64.0",
         "@theia/ai-vercel-ai": "1.64.0",
@@ -4557,21 +4560,17 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-16.10.0.tgz",
-      "integrity": "sha512-134PW/u/arNFAQKpqMJniC7irbChMPz+W+qtyKPAUXE0XFKPa7c1GtlI/wK2dvP9qJDZ6bKf0KtA0U/m2HMUOA==",
+      "version": "21.3.11",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-21.3.11.tgz",
+      "integrity": "sha512-pTBHuloqTxpTHa/fdKjHkFFsfW16mEcTp37HDtoQpjPfcd9nO8CYO8OClaewr9khNqCnSbCLfSoIg/alnb7BWw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
+      ]
     },
     "node_modules/@nx/nx-linux-x64-musl": {
       "version": "16.10.0",
@@ -5874,6 +5873,10 @@
     },
     "node_modules/@theia/ai-openai": {
       "resolved": "packages/ai-openai",
+      "link": true
+    },
+    "node_modules/@theia/ai-opencog": {
+      "resolved": "packages/ai-opencog",
       "link": true
     },
     "node_modules/@theia/ai-scanoss": {
@@ -20928,6 +20931,23 @@
         }
       }
     },
+    "node_modules/nx/node_modules/@nx/nx-linux-x64-gnu": {
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-16.10.0.tgz",
+      "integrity": "sha512-134PW/u/arNFAQKpqMJniC7irbChMPz+W+qtyKPAUXE0XFKPa7c1GtlI/wK2dvP9qJDZ6bKf0KtA0U/m2HMUOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/nx/node_modules/@parcel/watcher": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.4.tgz",
@@ -30808,6 +30828,24 @@
         "@theia/workspace": "1.64.0",
         "minimatch": "^5.1.0",
         "openai": "^5.0.1",
+        "tslib": "^2.6.2"
+      },
+      "devDependencies": {
+        "@theia/ext-scripts": "1.64.0"
+      }
+    },
+    "packages/ai-opencog": {
+      "name": "@theia/ai-opencog",
+      "version": "1.64.0",
+      "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
+      "dependencies": {
+        "@theia/ai-core": "1.64.0",
+        "@theia/core": "1.64.0",
+        "@theia/editor": "1.64.0",
+        "@theia/filesystem": "1.64.0",
+        "@theia/monaco": "1.64.0",
+        "@theia/variable-resolver": "1.64.0",
+        "@theia/workspace": "1.64.0",
         "tslib": "^2.6.2"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/express": "^4.17.21"
   },
   "devDependencies": {
+    "@nx/nx-linux-x64-gnu": "^21.3.11",
     "@types/chai": "4.3.0",
     "@types/chai-spies": "1.0.3",
     "@types/chai-string": "^1.4.0",

--- a/packages/ai-opencog/tsconfig.json
+++ b/packages/ai-opencog/tsconfig.json
@@ -1,10 +1,34 @@
 {
   "extends": "../../configs/base.tsconfig",
   "compilerOptions": {
+    "composite": true,
     "rootDir": "src",
     "outDir": "lib"
   },
   "include": [
     "src"
+  ],
+  "references": [
+    {
+      "path": "../ai-core"
+    },
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../editor"
+    },
+    {
+      "path": "../filesystem"
+    },
+    {
+      "path": "../monaco"
+    },
+    {
+      "path": "../variable-resolver"
+    },
+    {
+      "path": "../workspace"
+    }
   ]
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- Resolves `npm ci` failures caused by `package-lock.json` mismatch for `@theia/ai-opencog` and an outdated Node.js engine requirement.
- Updates `package-lock.json` to correctly include `@theia/ai-opencog` and adds `@nx/nx-linux-x64-gnu` to `devDependencies` to ensure successful dependency resolution and postinstall scripts for Nx/Lerna.
- Corrects `tsconfig.json` configurations for `examples/browser` and `packages/ai-opencog` to resolve TypeScript build errors related to `@theia/ai-opencog`.

#### How to test

1.  Ensure your Node.js version is 22.12.0 or higher.
2.  Run `npm ci` in the repository root. It should now complete successfully.
3.  (Optional) Verify `npm run build:browser` completes without TypeScript errors.

#### Follow-ups

- Consider updating the `engines` field in `package.json` to explicitly declare the required Node.js version (>=22.12.0) to prevent future `EBADENGINE` warnings.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

---
<a href="https://cursor.com/background-agent?bcId=bc-974c11ca-e9ad-4754-9b3e-2f72064320f3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-974c11ca-e9ad-4754-9b3e-2f72064320f3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

